### PR TITLE
Polish Ko-fi CTA and update contact layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,22 +151,6 @@ function setupForm() {
   });
 }
 
-function setupStickyCTA() {
-  const sticky = document.querySelector("[data-sticky-cta]");
-  if (!sticky) return;
-
-  const updateVisibility = () => {
-    if (window.innerWidth >= 768) {
-      sticky.style.position = "fixed";
-    } else {
-      sticky.style.position = "fixed";
-    }
-  };
-
-  updateVisibility();
-  window.addEventListener("resize", updateVisibility);
-}
-
 document.addEventListener("DOMContentLoaded", () => {
   applyLinks();
   setupReturnButtons();
@@ -174,5 +158,4 @@ document.addEventListener("DOMContentLoaded", () => {
   setupHeaderShadow();
   setupModals();
   setupForm();
-  setupStickyCTA();
 });

--- a/contact.html
+++ b/contact.html
@@ -45,12 +45,13 @@
     </div>
   </div>
 
-  <main class="container">
+  <main class="container contact-main">
     <div class="return-wrapper">
       <a class="btn btn--return" href="index.html" data-return><svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-arrow-left"></use></svg> Return</a>
     </div>
 
-    <section class="section">
+    <div class="contact-layout">
+      <section class="section contact-layout__panel">
       <h1 class="section__title">Reach out anytime</h1>
       <p>Need an update on drops, want a custom commission, or ready to collaborate? Choose a channel that’s easiest for you.</p>
       <div class="quick-links">
@@ -94,9 +95,9 @@
       <div class="section__actions">
         <a class="btn btn--primary" href="#" data-link="kofi">Shop on Ko-fi</a>
       </div>
-    </section>
+      </section>
 
-    <section class="section">
+      <section class="section contact-layout__panel">
       <h2 class="section__title">Send a note</h2>
       <form class="form" data-contact-form>
         <div class="form__group">
@@ -127,10 +128,7 @@
       <div class="section__actions">
         <a class="btn btn--secondary" href="services.html">See Services</a>
       </div>
-    </section>
-
-    <div class="return-wrapper">
-      <a class="btn btn--return" href="index.html" data-return><svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-arrow-left"></use></svg> Return</a>
+      </section>
     </div>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <section class="section hero" id="hero">
       <div class="container">
         <h1 class="hero__title">Hand-drawn dark aesthetics for your setup.</h1>
-        <p class="hero__subtitle">Limited drops. Made in Aklan.</p>
+        <p class="hero__subtitle">Limited edition handmade pieces and premium prints. Made in Aklan.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="#" data-link="kofi">Shop on Ko-fi <svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-external"></use></svg></a>
           <a class="btn btn--secondary" href="#" data-link="messenger">Message on Messenger <svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-messenger"></use></svg></a>
@@ -127,19 +127,19 @@
 
     <section class="section" id="handmade">
       <div class="container">
-        <h2 class="section__title">Why handmade?</h2>
+        <h2 class="section__title">Handmade &amp; printed, made for keeps</h2>
         <ul class="badge-list">
           <li class="badge-list__item">
             <svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-check"></use></svg>
-            <span>Hand-drawn, not machine-made</span>
+            <span>Hand-drawn originals finished by hand</span>
           </li>
           <li class="badge-list__item">
             <svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-check"></use></svg>
-            <span>Limited editions (numbered)</span>
+            <span>Limited handmade editions are signed &amp; numbered</span>
           </li>
           <li class="badge-list__item">
             <svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-check"></use></svg>
-            <span>Packed with care in Aklan</span>
+            <span>Premium prints for everyday setups</span>
           </li>
         </ul>
         <div class="section__actions">

--- a/services.html
+++ b/services.html
@@ -52,7 +52,7 @@
 
     <section class="section">
       <h1 class="section__title">Services <span style="color: rgba(242,239,230,0.6); font-size: 1rem; font-weight: 500;">(Coming Soon)</span></h1>
-      <p>We’re tuning the next wave of handmade drops. Explore what’s brewing and ping us for early access.</p>
+      <p>We’re tuning the next wave of handmade limiteds and polished print runs. Explore what’s brewing and ping us for early access.</p>
       <div class="section__actions">
         <a class="btn btn--primary" href="#" data-link="kofi">Shop on Ko-fi</a>
         <a class="btn btn--secondary" href="contact.html">Talk to us</a>
@@ -92,10 +92,6 @@
       <a class="btn btn--return" href="index.html" data-return><svg class="icon icon--primary" aria-hidden="true"><use href="icons.svg#icon-arrow-left"></use></svg> Return</a>
     </div>
   </main>
-
-  <div class="sticky-cta" data-sticky-cta>
-    <a class="btn btn--primary sticky-cta__button" href="#" data-link="kofi">Shop on Ko-fi</a>
-  </div>
 
   <footer class="footer">
     <div class="container footer__content">

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
   --bone: #F2EFE6;
   --red: #D22B2B;
   --red-700: #A41111;
-  --spooky: linear-gradient(180deg, #0B0B0B 0%, #14080B 45%, #24080A 100%);
+  --spooky: linear-gradient(180deg, #0b0b0b 0%, rgba(242, 239, 230, 0.08) 45%, #1b1b1f 100%);
   --max-width: 1200px;
   --transition: 0.25s ease;
 }
@@ -89,9 +89,22 @@ a:focus-visible,
   color: var(--bone);
 }
 
+.btn--primary .icon--primary {
+  color: currentColor;
+}
+
 .btn--primary:hover,
 .btn--primary:focus-visible {
   background: var(--red-700);
+}
+
+.btn--primary:active {
+  background: var(--bone);
+  color: var(--black);
+}
+
+.btn--primary:active .icon--primary {
+  color: var(--black);
 }
 
 .btn--secondary {
@@ -221,6 +234,10 @@ a:focus-visible,
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.header__actions .btn--primary {
+  white-space: nowrap;
 }
 
 .hamburger {
@@ -605,16 +622,19 @@ main {
   margin-block: 2rem;
 }
 
-.sticky-cta {
-  position: fixed;
-  right: 1rem;
-  bottom: 1.5rem;
-  z-index: 80;
+.contact-main {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
-.sticky-cta__button {
-  padding-inline: 1.75rem;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+.contact-layout {
+  display: grid;
+  gap: 3rem;
+}
+
+.contact-layout__panel {
+  background: transparent;
 }
 
 .lock-scroll {
@@ -664,27 +684,28 @@ main {
     justify-content: space-between;
     text-align: left;
   }
-
-  .sticky-cta {
-    top: 40%;
-    bottom: auto;
+  
+  .contact-main {
+    gap: 4rem;
   }
 }
 
 @media (min-width: 900px) {
-  .page--contact main {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 3rem;
+  .contact-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
   }
 
-  .page--contact main .section {
-    border-bottom: none;
+  .contact-layout__panel {
     padding-block: 0;
+    border-bottom: none;
   }
+}
 
-  .page--contact main {
-    padding-block: 4rem;
+@media (max-width: 480px) {
+  .header__actions .btn--primary {
+    padding-inline: 1rem;
+    font-size: 0.95rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the Ko-fi button legible on mobile, update primary button active styling, and cool down the spooky background gradient
- realign the contact quick links and form side by side on desktop while trimming the duplicate return link
- highlight both handmade and printed offerings in the copy and remove the stray services Ko-fi sticky button

## Testing
- Manually verified in browser (desktop & mobile views)


------
https://chatgpt.com/codex/tasks/task_e_68d907708d3483339ef07b3288127836