### PR TITLE
Rebrand services page and adjust button styling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
       </a>
       <nav class="nav" aria-label="Primary">
         <a class="nav__link" href="index.html">Home</a>
-        <a class="nav__link" href="services.html">Services</a>
+        <a class="nav__link" href="works.html">Works</a>
         <a class="nav__link" href="contact.html" aria-current="page">Contact</a>
       </nav>
       <div class="header__actions">
@@ -37,7 +37,7 @@
     </div>
     <nav class="drawer__nav" aria-label="Mobile">
       <a href="index.html">Home</a>
-      <a href="services.html">Services</a>
+      <a href="works.html">Works</a>
       <a href="contact.html" aria-current="page">Contact</a>
     </nav>
     <div class="drawer__footer">
@@ -126,7 +126,7 @@
         <button class="btn btn--primary" type="submit">Send message</button>
       </form>
       <div class="section__actions">
-        <a class="btn btn--secondary" href="services.html">See Services</a>
+        <a class="btn btn--secondary" href="works.html">See Works</a>
       </div>
       </section>
     </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       </a>
       <nav class="nav" aria-label="Primary">
         <a class="nav__link" href="index.html" aria-current="page">Home</a>
-        <a class="nav__link" href="services.html">Services</a>
+        <a class="nav__link" href="works.html">Works</a>
         <a class="nav__link" href="contact.html">Contact</a>
       </nav>
       <div class="header__actions">
@@ -40,7 +40,7 @@
     </div>
     <nav class="drawer__nav" aria-label="Mobile">
       <a href="index.html" aria-current="page">Home</a>
-      <a href="services.html">Services</a>
+      <a href="works.html">Works</a>
       <a href="contact.html">Contact</a>
     </nav>
     <div class="drawer__footer">
@@ -87,7 +87,7 @@
         <h2 class="section__title">About the Artist</h2>
         <p>Dedhare translates shadowy moods into tactile keepsakes. Each piece is drawn by hand, finished with archival textures, and made to haunt your workspace with quiet intensity.</p>
         <div class="section__actions">
-          <a class="btn btn--primary" href="services.html">See Services</a>
+          <a class="btn btn--primary" href="works.html">See Works</a>
           <a class="btn btn--secondary" href="contact.html">Contact Us</a>
         </div>
       </div>
@@ -101,7 +101,7 @@
             <h3 class="card__title">Stickers</h3>
             <p>Weather-sealed vinyl sigils, perfect for gear and cases.</p>
             <div class="section__actions">
-              <a class="btn btn--secondary" href="services.html">Learn more</a>
+              <a class="btn btn--secondary" href="works.html">Learn more</a>
               <a class="btn btn--primary" href="#" data-link="kofi">Order via Ko-fi</a>
             </div>
           </article>
@@ -109,7 +109,7 @@
             <h3 class="card__title">Drawings</h3>
             <p>Original sketches inked on heavyweight card, signed &amp; numbered.</p>
             <div class="section__actions">
-              <a class="btn btn--secondary" href="services.html">Learn more</a>
+              <a class="btn btn--secondary" href="works.html">Learn more</a>
               <a class="btn btn--primary" href="#" data-link="kofi">Order via Ko-fi</a>
             </div>
           </article>
@@ -117,7 +117,7 @@
             <h3 class="card__title">Digital Works</h3>
             <p>High-resolution art packs for your wallpapers and streams.</p>
             <div class="section__actions">
-              <a class="btn btn--secondary" href="services.html">Learn more</a>
+              <a class="btn btn--secondary" href="works.html">Learn more</a>
               <a class="btn btn--primary" href="#" data-link="kofi">Order via Ko-fi</a>
             </div>
           </article>

--- a/styles.css
+++ b/styles.css
@@ -103,11 +103,11 @@ a:focus-visible,
 
 .btn--primary:active {
   background: var(--bone);
-  color: var(--black);
+  color: var(--red);
 }
 
 .btn--primary:active .icon--primary {
-  color: var(--black);
+  color: var(--red);
 }
 
 .btn--secondary {
@@ -553,12 +553,12 @@ main {
   outline-offset: 2px;
 }
 
-.services__list {
+.works__list {
   display: grid;
   gap: 2rem;
 }
 
-.service {
+.work {
   display: grid;
   gap: 1rem;
   background: rgba(20, 8, 11, 0.65);
@@ -567,7 +567,7 @@ main {
   padding: 2rem;
 }
 
-.service__actions {
+.work__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
@@ -622,7 +622,7 @@ main {
 }
 
 .return-wrapper {
-  margin-block: 2rem;
+  margin-block: 0.5rem;
 }
 
 .contact-main {

--- a/works.html
+++ b/works.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Services · Dedhare &amp; Works</title>
+  <title>Works · Dedhare &amp; Works</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="page page--services">
+<body class="page page--works">
   <header class="header" role="banner">
     <div class="container header__inner">
       <a class="logo" href="index.html">
@@ -15,7 +15,7 @@
       </a>
       <nav class="nav" aria-label="Primary">
         <a class="nav__link" href="index.html">Home</a>
-        <a class="nav__link" href="services.html" aria-current="page">Services</a>
+        <a class="nav__link" href="works.html" aria-current="page">Works</a>
         <a class="nav__link" href="contact.html">Contact</a>
       </nav>
       <div class="header__actions">
@@ -37,7 +37,7 @@
     </div>
     <nav class="drawer__nav" aria-label="Mobile">
       <a href="index.html">Home</a>
-      <a href="services.html" aria-current="page">Services</a>
+      <a href="works.html" aria-current="page">Works</a>
       <a href="contact.html">Contact</a>
     </nav>
     <div class="drawer__footer">
@@ -51,7 +51,7 @@
     </div>
 
     <section class="section">
-      <h1 class="section__title">Services <span style="color: rgba(242,239,230,0.6); font-size: 1rem; font-weight: 500;">(Coming Soon)</span></h1>
+      <h1 class="section__title">Works <span style="color: rgba(242,239,230,0.6); font-size: 1rem; font-weight: 500;">(Coming Soon)</span></h1>
       <p>We’re tuning the next wave of handmade limiteds and polished print runs. Explore what’s brewing and ping us for early access.</p>
       <div class="section__actions">
         <a class="btn btn--primary" href="#" data-link="kofi">Shop on Ko-fi</a>
@@ -60,27 +60,27 @@
     </section>
 
     <section class="section">
-      <div class="services__list">
-        <article class="service">
+      <div class="works__list">
+        <article class="work">
           <h2>Sticker Drops</h2>
           <p>Limited batches, signed &amp; numbered.</p>
-          <div class="service__actions">
+          <div class="work__actions">
             <a class="btn btn--primary" href="#" data-link="kofi">Order via Ko-fi</a>
             <a class="btn btn--secondary" href="contact.html">Contact Us</a>
           </div>
         </article>
-        <article class="service">
+        <article class="work">
           <h2>Custom Commissions</h2>
           <p>Tell us your idea; we’ll advise scope &amp; pricing.</p>
-          <div class="service__actions">
+          <div class="work__actions">
             <a class="btn btn--secondary" href="contact.html">Request a Quote</a>
             <a class="btn btn--primary" href="#" data-link="messenger">Message on Messenger</a>
           </div>
         </article>
-        <article class="service">
+        <article class="work">
           <h2>Gifts &amp; Packaging</h2>
           <p>For friends with dark taste.</p>
-          <div class="service__actions">
+          <div class="work__actions">
             <a class="btn btn--secondary" href="contact.html">Ask About Gift Packs</a>
             <a class="btn btn--primary" href="#" data-link="kofi">Shop on Ko-fi</a>
           </div>


### PR DESCRIPTION
## Summary
- rename the services page to Works and update the navigation and buttons to match the new branding
- refresh the Works page markup and supporting styles to use the updated naming
- reduce the return button spacing and keep primary button text red when pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90e39d0c883339554e56701ca2d24